### PR TITLE
Added totals for more multipliers, fixed bugs

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,7 +78,7 @@ angular.module('PathOfDamage', [])
 
     var shifts = $scope.sections.shift.tables.shifts.total / 100;
     var shifted = hit * shifts * (1 - $scope.resistance / 100);
-    hit *= (1 - shifts);
+    hit -= shifted;
 
     var armor = $scope.sections.mitigation.armor / ($scope.sections.mitigation.armor + 10 * hit);
     var endurance = $scope.sections.mitigation.charges * .04;

--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ angular.module('PathOfDamage', [])
   };
 
   $scope.updateTotal = function (table, skipUpdates) {
-    table.totalCalc(table);
+    table.totalCalc();
     if (!skipUpdates) {
       $scope.updateDamageValues();
     }

--- a/index.html
+++ b/index.html
@@ -54,10 +54,7 @@
           </td>
         </tr>
       </table>
-
-      <h5 ng-if="table.total !== undefined">
-        <b>Total {{table.totalName}}: {{table.total}}{{tableName !== 'flat' ? '%' : ''}}</b>
-      </h5>
+      <b>Total {{table.totalName}}: {{table.total}}{{tableName !== 'flat' ? '%' : ''}}</b>
       <hr ng-repeat-end>
     </div>
   </div>


### PR DESCRIPTION
Added totals for more multipliers (which also led me to fix a bug in my more damage calculations). In order to make the math work smoothly for this I changed damage taken to be increases, which also makes it a little more consistent with monster damage at the beginning. Still different than additional damage mitigation and damage shift though. We might want to change input in the UI and just flip the variables when they are saved...but it seems nice for negatives to be more consistent at lowering damage taken?